### PR TITLE
chore/Update autotag_retro_main-template.json

### DIFF
--- a/cloud_formation/autotag_retro_main-template.json
+++ b/cloud_formation/autotag_retro_main-template.json
@@ -70,7 +70,7 @@
         },
         "Handler" : "autotag_log.handler",
         "Role" : { "Fn::GetAtt" : [ "AutoTagExecutionRole", "Arn" ] },
-        "Runtime" : "nodejs10.x",
+        "Runtime" : "nodejs18.x",
         "Timeout" : 300,
         "Environment": {
           "Variables": {


### PR DESCRIPTION
Updates the retro tag's lambda runtime to node18x.